### PR TITLE
fix(round_robin): randomize starting index to distribute load across targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@athenna/ratelimiter",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "Respect the rate limit rules of API's you need to consume.",
   "license": "MIT",
   "author": "João Lenon <lenon@athenna.io>",

--- a/src/ratelimiter/RateLimiterBuilder.ts
+++ b/src/ratelimiter/RateLimiterBuilder.ts
@@ -628,7 +628,7 @@ export class RateLimiterBuilder extends Macroable {
 
       const nextItem = this.queue[0]
 
-      if (this.rrIndex === null) {
+      if (this.options.targetSelectionStrategy === 'round_robin' && this.rrIndex === null) {
         this.rrIndex = Math.floor(Math.random() * this.options.targets.length)
       }
 

--- a/src/ratelimiter/RateLimiterBuilder.ts
+++ b/src/ratelimiter/RateLimiterBuilder.ts
@@ -64,8 +64,9 @@ export class RateLimiterBuilder extends Macroable {
 
   /**
    * Index for when using round_robin selection strategy.
+   * Starts as null to indicate it has not been randomly initialized yet.
    */
-  private rrIndex = 0
+  private rrIndex: number | null = null
 
   /**
    * Holds the setTimeout id to be able to disable it
@@ -553,6 +554,9 @@ export class RateLimiterBuilder extends Macroable {
 
     switch (this.options.targetSelectionStrategy) {
       case 'round_robin':
+        if (this.rrIndex === null) {
+          this.rrIndex = Math.floor(Math.random() * this.options.targets.length)
+        }
         indexes = this.createRoundRobinIdx()
         break
       case 'first_available':

--- a/src/ratelimiter/RateLimiterBuilder.ts
+++ b/src/ratelimiter/RateLimiterBuilder.ts
@@ -554,9 +554,6 @@ export class RateLimiterBuilder extends Macroable {
 
     switch (this.options.targetSelectionStrategy) {
       case 'round_robin':
-        if (this.rrIndex === null) {
-          this.rrIndex = Math.floor(Math.random() * this.options.targets.length)
-        }
         indexes = this.createRoundRobinIdx()
         break
       case 'first_available':
@@ -630,6 +627,10 @@ export class RateLimiterBuilder extends Macroable {
       let target: RateLimitTarget = null
 
       const nextItem = this.queue[0]
+
+      if (this.rrIndex === null) {
+        this.rrIndex = Math.floor(Math.random() * this.options.targets.length)
+      }
 
       for (const i of this.createIdxBySelectionStrategy(nextItem)) {
         const possibleTarget = this.options.targets[i]

--- a/tests/unit/ratelimiter/RateLimiterBuilderTest.ts
+++ b/tests/unit/ratelimiter/RateLimiterBuilderTest.ts
@@ -792,6 +792,103 @@ export class RateLimiterBuilderTest {
   }
 
   @Test()
+  public async shouldRotateTargetsSequentiallyWhenUsingRoundRobinStrategy({ assert }: Context) {
+    const targets = [
+      { id: 'api1', metadata: { baseUrl: 'http://api1.com' } },
+      { id: 'api2', metadata: { baseUrl: 'http://api2.com' } },
+      { id: 'api3', metadata: { baseUrl: 'http://api3.com' } }
+    ]
+
+    const limiter = RateLimiter.build()
+      .store('memory', { windowMs: { second: 1000 } })
+      .key('request:rr-rotation')
+      .targetSelectionStrategy('round_robin')
+      .addRule({ type: 'second', limit: 100 })
+      .setTargets(targets)
+
+    const results: string[] = []
+
+    for (let i = 0; i < 6; i++) {
+      const result = await limiter.schedule(({ target }) => target.metadata.baseUrl)
+      results.push(result)
+    }
+
+    const urls = ['http://api1.com', 'http://api2.com', 'http://api3.com']
+    const startIdx = urls.indexOf(results[0])
+    const expected = Array.from({ length: 6 }, (_, i) => urls[(startIdx + i) % 3])
+
+    assert.deepEqual(results, expected)
+  }
+
+  @Test()
+  public async shouldRotateTargetsConcurrentlyWhenUsingRoundRobinStrategy({ assert }: Context) {
+    const api1 = { id: 'api1', metadata: { baseUrl: 'http://api1.com' } }
+    const api2 = { id: 'api2', metadata: { baseUrl: 'http://api2.com' } }
+
+    const limiter = RateLimiter.build()
+      .maxConcurrent(2)
+      .store('memory', { windowMs: { second: 100 } })
+      .key('request:rr-rotation-concurrent')
+      .targetSelectionStrategy('round_robin')
+      .addRule({ type: 'second', limit: 10 })
+      .addTarget(api1)
+      .addTarget(api2)
+
+    const used: string[] = []
+    const barrier = this.createBarrier()
+
+    const run = async ({ target }) => {
+      used.push(target.metadata.baseUrl)
+      await barrier.wait()
+      return target.metadata.baseUrl
+    }
+
+    const p1 = limiter.schedule(run)
+    const p2 = limiter.schedule(run)
+
+    await this.waitUntil(() => used.length === 2, 10, 1000)
+
+    used.sort()
+
+    assert.deepEqual(used, ['http://api1.com', 'http://api2.com'])
+
+    barrier.release()
+
+    const results = await Promise.all([p1, p2])
+
+    results.sort()
+
+    assert.deepEqual(results, ['http://api1.com', 'http://api2.com'])
+  }
+
+  @Test()
+  public async shouldDistributeStartingTargetAcrossMultipleInstancesWhenUsingRoundRobinStrategy({ assert }: Context) {
+    const api1 = { id: 'api1', metadata: { baseUrl: 'http://api1.com' } }
+    const api2 = { id: 'api2', metadata: { baseUrl: 'http://api2.com' } }
+
+    const firstTargets: string[] = []
+
+    for (let run = 0; run < 20; run++) {
+      const limiter = RateLimiter.build()
+        .store('memory', { windowMs: { second: 1000 } })
+        .key(`request:rr-dist-${run}`)
+        .targetSelectionStrategy('round_robin')
+        .addRule({ type: 'second', limit: 100 })
+        .addTarget(api1)
+        .addTarget(api2)
+
+      const result = await limiter.schedule(({ target }) => target.metadata.baseUrl)
+      firstTargets.push(result)
+    }
+
+    const api1Count = firstTargets.filter(t => t === 'http://api1.com').length
+    const api2Count = firstTargets.filter(t => t === 'http://api2.com').length
+
+    assert.isAbove(api1Count, 0)
+    assert.isAbove(api2Count, 0)
+  }
+
+  @Test()
   public async shouldThrowMissingRuleExceptionIfRateLimiterRulesAndTargetRulesAreNotDefined({ assert }: Context) {
     const limiter = RateLimiter.build()
       .store('memory', { windowMs: { second: 100 } })


### PR DESCRIPTION
## Summary

- Round robin strategy now picks a random starting target on first use, then rotates deterministically
- This ensures new limiter instances (created per-request) distribute load evenly instead of always starting at target[0], which made `round_robin` behave identically to `first_available`
- Adds tests for sequential rotation, concurrent rotation, and distribution across multiple instances

## Context

When consumers create a new `RateLimiter` instance per request (e.g. the socials API), `rrIndex` always started at `0`. Every request would hit target[0] first, making `round_robin` indistinguishable from `first_available`.

The fix initializes `rrIndex` to a random value on first use (`rrIndex: number | null = null`), so each instance starts at a different target. After that, rotation proceeds deterministically.